### PR TITLE
Fix : prevent clubs from exceeding their allowed points

### DIFF
--- a/server.py
+++ b/server.py
@@ -37,6 +37,11 @@ competitions = loadCompetitions()
 clubs = loadClubs()
 
 
+def has_enough_points(club: dict, requested: int) -> bool:
+    """check if the club has enough points to book the requested places """
+    return int(club['points']) >= requested
+
+
 @app.route('/')
 def index():
     return render_template('index.html')
@@ -82,11 +87,20 @@ def book(competition,club):
 @app.route('/purchasePlaces',methods=['POST'])
 @login_required
 def purchasePlaces():
-    competition = [c for c in competitions if c['name'] == request.form['competition']][0]
-    club = [c for c in clubs if c['name'] == request.form['club']][0]
+    club_name = session.get('club')['name']
+    club = next(c for c in clubs if c['name'] == club_name)
+
+    competition = next(c for c in competitions
+                       if c['name'] == request.form['competition'])
+
     placesRequired = int(request.form['places'])
-    competition['numberOfPlaces'] = int(competition['numberOfPlaces'])-placesRequired
-    flash('Great-booking complete!')
+
+    if not has_enough_points(club, placesRequired):
+        flash("you don't have enough points")
+    else:
+        competition['numberOfPlaces'] = int(competition['numberOfPlaces'])-placesRequired
+        flash('Great-booking complete!')
+
     return render_template('welcome.html',
                            club=club,
                            competitions=competitions)

--- a/server.py
+++ b/server.py
@@ -98,7 +98,7 @@ def purchasePlaces():
     if not has_enough_points(club, placesRequired):
         flash("you don't have enough points")
     else:
-        competition['numberOfPlaces'] = int(competition['numberOfPlaces'])-placesRequired
+        competition['numberOfPlaces'] = str(int(competition['numberOfPlaces'])-placesRequired)
         flash('Great-booking complete!')
 
     return render_template('welcome.html',

--- a/tests/test_functional_server.py
+++ b/tests/test_functional_server.py
@@ -120,3 +120,43 @@ def test_logout_clears_session_and_redirects(client, mocker, fake_data):
 
     assert response.status_code == 200
     assert b"secretary email" in response.data
+
+
+def test_successful_booking(client, mocker, fake_data):
+    clubs, competitions = fake_data
+    mocker.patch("server.clubs", clubs)
+    mocker.patch("server.competitions", competitions)
+
+    client.post('/login', data={'email': clubs[0]['email']},
+                follow_redirects=True)
+
+    response = client.post('/purchasePlaces', data={
+        'competition': competitions[1]['name'],
+        'club': clubs[0]['name'],
+        'places': '1'
+    }, follow_redirects=True)
+
+    assert response.status_code == 200
+    assert b"Great-booking complete!" in response.data
+    assert competitions[1]['numberOfPlaces'] == '4'
+
+
+def test_booking_without_enough_points(client, mocker, fake_data):
+    clubs, competitions = fake_data
+    club = clubs[0]
+    club["points"] = "0"
+
+    competition = competitions[1]
+    mocker.patch("server.clubs", clubs)
+    mocker.patch("server.competitions", competitions)
+
+    client.post('/login', data={'email': club['email']}, follow_redirects=True)
+
+    response = client.post('/purchasePlaces', data={
+        'competition': competition['name'],
+        'club': club['name'],
+        'places': '1'
+    }, follow_redirects=True)
+
+    assert b"you don&#39;t have enough points" in response.data
+

--- a/tests/test_unitaire_server.py
+++ b/tests/test_unitaire_server.py
@@ -1,0 +1,12 @@
+import pytest
+from server import has_enough_points
+
+
+def test_has_enough_points_true():
+    club = {'points': '10'}
+    assert has_enough_points(club, 5) is True
+
+
+def test_has_enough_points_false():
+    club = {'points': '2'}
+    assert has_enough_points(club, 3) is False


### PR DESCRIPTION
### What does this PR do?
This PR prevents clubs from spending more points than they have. 
It adds the function has_enough_points  that compares the club’s points and  the requested places and returns a boolean

### Closes Issue(s)
Closes #2

### How to test
- Execute :  flask --app server run
- Login with a valid email : admin@irontemple.com
![image](https://github.com/user-attachments/assets/45ad7431-28c6-4cd4-97cb-41f7d5b6e981)
- Choose the link "Book Places"
- Enter a integer 5 and click Book
![Capture d'écran 2025-05-15 164908](https://github.com/user-attachments/assets/20b6b0e9-ff28-43b9-acc7-529a849845a7)

- Then the error message is displayed
![Capture d'écran 2025-05-15 164944](https://github.com/user-attachments/assets/959b2624-ca56-4fc2-94b7-061014bc5c4d)

### More
- The unit tests and the fonctionnal tests using Pytest are included