### PR TITLE
Fix: prevents clubs from reserving more than the available places

### DIFF
--- a/server.py
+++ b/server.py
@@ -42,6 +42,11 @@ def has_enough_points(club: dict, requested: int) -> bool:
     return int(club['points']) >= requested
 
 
+def has_enough_places_available(competition: dict, placesRequired: int) -> bool:
+    """Check that the competition has more places available than requested"""
+    return int(competition['numberOfPlaces']) > placesRequired
+
+
 @app.route('/')
 def index():
     return render_template('index.html')
@@ -97,6 +102,8 @@ def purchasePlaces():
 
     if not has_enough_points(club, placesRequired):
         flash("you don't have enough points")
+    elif not has_enough_places_available(competition, placesRequired):
+        flash("there are not enough places available")
     else:
         competition['numberOfPlaces'] = str(int(competition['numberOfPlaces'])-placesRequired)
         flash('Great-booking complete!')

--- a/tests/test_functional_server.py
+++ b/tests/test_functional_server.py
@@ -160,3 +160,22 @@ def test_booking_without_enough_points(client, mocker, fake_data):
 
     assert b"you don&#39;t have enough points" in response.data
 
+
+def test_booking_more_than_available_places(client, mocker, fake_data):
+    clubs, competitions = fake_data
+    club = clubs[0]
+    competition = competitions[1]
+
+    mocker.patch("server.clubs", clubs)
+    mocker.patch("server.competitions", competitions)
+
+    client.post('/login', data={'email': club['email']}, follow_redirects=True)
+
+    response = client.post('/purchasePlaces', data={
+        'competition': competition['name'],
+        'club': club['name'],
+        'places': '7'
+    }, follow_redirects=True)
+
+    assert b"there are not enough places available" in response.data
+

--- a/tests/test_unitaire_server.py
+++ b/tests/test_unitaire_server.py
@@ -1,5 +1,5 @@
 import pytest
-from server import has_enough_points
+from server import has_enough_points, has_enough_places_available
 
 
 def test_has_enough_points_true():
@@ -10,3 +10,19 @@ def test_has_enough_points_true():
 def test_has_enough_points_false():
     club = {'points': '2'}
     assert has_enough_points(club, 3) is False
+
+
+def test_has_enough_places_available():
+    competition = {
+        'numberOfPlaces': '10',
+    }
+    placesRequested = 5
+    assert has_enough_places_available(competition, placesRequested) is True
+
+
+def test_has_not_enough_places_available():
+    competition = {
+        'numberOfPlaces': '8',
+    }
+    placesRequested = 10
+    assert has_enough_places_available(competition, placesRequested) is False


### PR DESCRIPTION
### What does this PR do?
This PR prevents clubs from reserving more than the available places in the competition. It add the function  has_enough_places_available which ckecks that the competition has more places available than requested and return a boolean

### Closes Issue(s)

closes #282

### How to test
- Execute : flask --app server run
- Login with a valid email : john@simplylift.co
- click on Fall Classic Book Places link 
![Capture d'écran 2025-05-15 171053](https://github.com/user-attachments/assets/52ed78b9-8f02-47ee-b3f7-3a9388b13967)

- Try to book 10 places
- The number of places are reduced to 3
![Capture d'écran 2025-05-15 171429](https://github.com/user-attachments/assets/ae938597-44f7-4407-8d4e-b123822706a1)
- click again on Fall Classic Book Places link
- Try to book 5
- The error message is displayed. 
![Capture d'écran 2025-05-15 171401](https://github.com/user-attachments/assets/cbb7e322-1d15-4215-a40e-91c6d1e20add)

### More
-The unit tests and the fonctionnal tests using Pytest are included
