### PR TITLE
Fix: limit club bookings to 12 places per competition

### DIFF
--- a/server.py
+++ b/server.py
@@ -24,24 +24,10 @@ def loadClubs():
          return listOfClubs
 
 
-def saveClubs(listOfClubs: list, file_path: str = 'clubs.json'):
-    """ save the list of club in the clubs.json file """
-    with open(file_path, 'w') as c:
-        json.dump({'clubs': listOfClubs}, c, indent=4)
-
-
-def loadCompetitions() -> list:
-    """ Read the competitions.json file and return a list of competitions """
+def loadCompetitions():
     with open('competitions.json') as comps:
-        listOfCompetitions = json.load(comps)['competitions']
-        return listOfCompetitions
-
-
-def saveCompetitions(listOfCompetitions: list,
-                     file_path: str = 'competitions.json'):
-    """ save the list of competition in the competitions.json file """
-    with open(file_path, 'w') as c:
-        json.dump({'competitions': listOfCompetitions}, c, indent=4)
+         listOfCompetitions = json.load(comps)['competitions']
+         return listOfCompetitions
 
 
 app = Flask(__name__)
@@ -59,29 +45,6 @@ def has_enough_points(club: dict, requested: int) -> bool:
 def has_enough_places_available(competition: dict, placesRequired: int) -> bool:
     """Check that the competition has more places available than requested"""
     return int(competition['numberOfPlaces']) > placesRequired
-
-
-def is_booking_limit_exceeded(club_name: str, competition: dict,
-                              requested: int) -> bool:
-    """ check if the club is trying to book more than 12 places """
-    bookedPlaces = int(competition.get("bookings", {}).get(club_name, 0))
-    return bookedPlaces + requested > 12
-
-
-def update_booking(club: dict, competition: dict, requested: int) -> None:
-    """
-    updates the club and competition after a booking,
-    creates the dictionary "booking" for the competition if it doesn't exist
-    """
-    club['points'] = str(int(club['points']) - requested)
-    competition['numberOfPlaces'] = str(
-        int(competition['numberOfPlaces']) - requested)
-
-    if "bookings" not in competition:
-        competition["bookings"] = {}
-
-    bookedPlaces = int(competition["bookings"].get(club['name'], 0))
-    competition["bookings"][club['name']] = str(bookedPlaces + requested)
 
 
 @app.route('/')
@@ -137,15 +100,12 @@ def purchasePlaces():
 
     placesRequired = int(request.form['places'])
 
-    if is_booking_limit_exceeded(club['name'], competition, placesRequired):
-        flash("you can't book more than 12 places.")
-    elif not has_enough_points(club, placesRequired):
+    if not has_enough_points(club, placesRequired):
         flash("you don't have enough points")
     elif not has_enough_places_available(competition, placesRequired):
         flash("there are not enough places available")
     else:
-        update_booking(club, competition, placesRequired)
-
+        competition['numberOfPlaces'] = str(int(competition['numberOfPlaces'])-placesRequired)
         flash('Great-booking complete!')
 
     return render_template('welcome.html',

--- a/server.py
+++ b/server.py
@@ -24,10 +24,24 @@ def loadClubs():
          return listOfClubs
 
 
-def loadCompetitions():
+def saveClubs(listOfClubs: list, file_path: str = 'clubs.json'):
+    """ save the list of club in the clubs.json file """
+    with open(file_path, 'w') as c:
+        json.dump({'clubs': listOfClubs}, c, indent=4)
+
+
+def loadCompetitions() -> list:
+    """ Read the competitions.json file and return a list of competitions """
     with open('competitions.json') as comps:
-         listOfCompetitions = json.load(comps)['competitions']
-         return listOfCompetitions
+        listOfCompetitions = json.load(comps)['competitions']
+        return listOfCompetitions
+
+
+def saveCompetitions(listOfCompetitions: list,
+                     file_path: str = 'competitions.json'):
+    """ save the list of competition in the competitions.json file """
+    with open(file_path, 'w') as c:
+        json.dump({'competitions': listOfCompetitions}, c, indent=4)
 
 
 app = Flask(__name__)
@@ -131,6 +145,9 @@ def purchasePlaces():
         flash("there are not enough places available")
     else:
         update_booking(club, competition, placesRequired)
+        saveClubs(clubs)
+        saveCompetitions(competitions)
+
         flash('Great-booking complete!')
 
     return render_template('welcome.html',

--- a/server.py
+++ b/server.py
@@ -24,10 +24,24 @@ def loadClubs():
          return listOfClubs
 
 
-def loadCompetitions():
+def saveClubs(listOfClubs: list, file_path: str = 'clubs.json'):
+    """ save the list of club in the clubs.json file """
+    with open(file_path, 'w') as c:
+        json.dump({'clubs': listOfClubs}, c, indent=4)
+
+
+def loadCompetitions() -> list:
+    """ Read the competitions.json file and return a list of competitions """
     with open('competitions.json') as comps:
-         listOfCompetitions = json.load(comps)['competitions']
-         return listOfCompetitions
+        listOfCompetitions = json.load(comps)['competitions']
+        return listOfCompetitions
+
+
+def saveCompetitions(listOfCompetitions: list,
+                     file_path: str = 'competitions.json'):
+    """ save the list of competition in the competitions.json file """
+    with open(file_path, 'w') as c:
+        json.dump({'competitions': listOfCompetitions}, c, indent=4)
 
 
 app = Flask(__name__)
@@ -45,6 +59,29 @@ def has_enough_points(club: dict, requested: int) -> bool:
 def has_enough_places_available(competition: dict, placesRequired: int) -> bool:
     """Check that the competition has more places available than requested"""
     return int(competition['numberOfPlaces']) > placesRequired
+
+
+def is_booking_limit_exceeded(club_name: str, competition: dict,
+                              requested: int) -> bool:
+    """ check if the club is trying to book more than 12 places """
+    bookedPlaces = int(competition.get("bookings", {}).get(club_name, 0))
+    return bookedPlaces + requested > 12
+
+
+def update_booking(club: dict, competition: dict, requested: int) -> None:
+    """
+    updates the club and competition after a booking,
+    creates the dictionary "booking" for the competition if it doesn't exist
+    """
+    club['points'] = str(int(club['points']) - requested)
+    competition['numberOfPlaces'] = str(
+        int(competition['numberOfPlaces']) - requested)
+
+    if "bookings" not in competition:
+        competition["bookings"] = {}
+
+    bookedPlaces = int(competition["bookings"].get(club['name'], 0))
+    competition["bookings"][club['name']] = str(bookedPlaces + requested)
 
 
 @app.route('/')
@@ -100,12 +137,15 @@ def purchasePlaces():
 
     placesRequired = int(request.form['places'])
 
-    if not has_enough_points(club, placesRequired):
+    if is_booking_limit_exceeded(club['name'], competition, placesRequired):
+        flash("you can't book more than 12 places.")
+    elif not has_enough_points(club, placesRequired):
         flash("you don't have enough points")
     elif not has_enough_places_available(competition, placesRequired):
         flash("there are not enough places available")
     else:
-        competition['numberOfPlaces'] = str(int(competition['numberOfPlaces'])-placesRequired)
+        update_booking(club, competition, placesRequired)
+
         flash('Great-booking complete!')
 
     return render_template('welcome.html',

--- a/server.py
+++ b/server.py
@@ -47,6 +47,13 @@ def has_enough_places_available(competition: dict, placesRequired: int) -> bool:
     return int(competition['numberOfPlaces']) > placesRequired
 
 
+def is_booking_limit_exceeded(club_name: str, competition: dict,
+                              requested: int) -> bool:
+    """ check if the club is trying to book more than 12 places """
+    bookedPlaces = int(competition.get("bookings", {}).get(club_name, 0))
+    return bookedPlaces + requested > 12
+
+
 @app.route('/')
 def index():
     return render_template('index.html')
@@ -100,7 +107,9 @@ def purchasePlaces():
 
     placesRequired = int(request.form['places'])
 
-    if not has_enough_points(club, placesRequired):
+    if is_booking_limit_exceeded(club['name'], competition, placesRequired):
+        flash("you can't book more than 12 places.")
+    elif not has_enough_points(club, placesRequired):
         flash("you don't have enough points")
     elif not has_enough_places_available(competition, placesRequired):
         flash("there are not enough places available")

--- a/server.py
+++ b/server.py
@@ -54,6 +54,22 @@ def is_booking_limit_exceeded(club_name: str, competition: dict,
     return bookedPlaces + requested > 12
 
 
+def update_booking(club: dict, competition: dict, requested: int) -> None:
+    """
+    updates the club and competition after a booking,
+    creates the dictionary "booking" for the competition if it doesn't exist
+    """
+    club['points'] = str(int(club['points']) - requested)
+    competition['numberOfPlaces'] = str(
+        int(competition['numberOfPlaces']) - requested)
+
+    if "bookings" not in competition:
+        competition["bookings"] = {}
+
+    bookedPlaces = int(competition["bookings"].get(club['name'], 0))
+    competition["bookings"][club['name']] = str(bookedPlaces + requested)
+
+
 @app.route('/')
 def index():
     return render_template('index.html')
@@ -114,7 +130,7 @@ def purchasePlaces():
     elif not has_enough_places_available(competition, placesRequired):
         flash("there are not enough places available")
     else:
-        competition['numberOfPlaces'] = str(int(competition['numberOfPlaces'])-placesRequired)
+        update_booking(club, competition, placesRequired)
         flash('Great-booking complete!')
 
     return render_template('welcome.html',

--- a/tests/test_functional_server.py
+++ b/tests/test_functional_server.py
@@ -126,6 +126,8 @@ def test_successful_booking(client, mocker, fake_data):
     clubs, competitions = fake_data
     mocker.patch("server.clubs", clubs)
     mocker.patch("server.competitions", competitions)
+    mocker.patch("server.saveClubs")
+    mocker.patch("server.saveCompetitions")
 
     client.post('/login', data={'email': clubs[0]['email']},
                 follow_redirects=True)
@@ -149,6 +151,8 @@ def test_booking_without_enough_points(client, mocker, fake_data):
     competition = competitions[1]
     mocker.patch("server.clubs", clubs)
     mocker.patch("server.competitions", competitions)
+    mocker.patch("server.saveClubs")
+    mocker.patch("server.saveCompetitions")
 
     client.post('/login', data={'email': club['email']}, follow_redirects=True)
 
@@ -168,6 +172,8 @@ def test_booking_more_than_available_places(client, mocker, fake_data):
 
     mocker.patch("server.clubs", clubs)
     mocker.patch("server.competitions", competitions)
+    mocker.patch("server.saveClubs")
+    mocker.patch("server.saveCompetitions")
 
     client.post('/login', data={'email': club['email']}, follow_redirects=True)
 
@@ -178,4 +184,27 @@ def test_booking_more_than_available_places(client, mocker, fake_data):
     }, follow_redirects=True)
 
     assert b"there are not enough places available" in response.data
+
+
+def test_booking_too_much_places(client, mocker, fake_data):
+    clubs, competitions = fake_data
+    club = clubs[0]
+    competition = competitions[1]
+    competition['place'] = "25"
+
+    mocker.patch("server.clubs", clubs)
+    mocker.patch("server.competitions", competitions)
+
+    mocker.patch("server.saveClubs")
+    mocker.patch("server.saveCompetitions")
+
+    client.post('/login', data={'email': club['email']}, follow_redirects=True)
+
+    response = client.post('/purchasePlaces', data={
+        'competition': competition['name'],
+        'club': club['name'],
+        'places': '15'
+    }, follow_redirects=True)
+
+    assert b"you can&#39;t book more than 12 places." in response.data
 

--- a/tests/test_integration-server.py
+++ b/tests/test_integration-server.py
@@ -1,5 +1,6 @@
 import pytest
-from server import app, loadClubs, loadCompetitions
+from server import app, loadClubs, loadCompetitions, saveClubs, \
+    saveCompetitions, clubs, competitions
 
 
 @pytest.fixture
@@ -31,3 +32,44 @@ def test_load_competitions_reads_json_file(mocker):
 
     result = loadCompetitions()
     assert result[0]["name"] == "Fake Competition"
+
+
+def test_save_clubs_calls_json_dump(mocker):
+    mock_open = mocker.mock_open()
+    mocker.patch("builtins.open", mock_open)
+    mock_dump = mocker.patch("json.dump")
+
+    saveClubs([{"name": "X", "points": "1"}])
+
+    mock_dump.assert_called_once()
+
+
+def test_save_competitions_calls_json_dump(mocker):
+    mock_open = mocker.mock_open()
+    mocker.patch("builtins.open", mock_open)
+    mock_dump = mocker.patch("json.dump")
+
+    saveCompetitions([{"name": "X", "points": "1"}])
+
+    mock_dump.assert_called_once()
+
+
+def test_booking_calls_saves(mocker, client):
+    club = clubs[0]
+    competition = competitions[1]
+
+    mock_save_clubs = mocker.patch("server.saveClubs")
+    mock_save_comps = mocker.patch("server.saveCompetitions")
+
+    client.post('/login', data={'email': club['email']}, follow_redirects=True)
+    response = client.post('/purchasePlaces', data={
+        'competition': competition['name'],
+        'club': club['name'],
+        'places': '1'
+    }, follow_redirects=True)
+
+    assert response.status_code == 200
+    assert b"Great-booking complete!" in response.data
+    mock_save_clubs.assert_called_once()
+    mock_save_comps.assert_called_once()
+

--- a/tests/test_unitaire_server.py
+++ b/tests/test_unitaire_server.py
@@ -1,5 +1,6 @@
 import pytest
-from server import has_enough_points, has_enough_places_available
+from server import has_enough_points, has_enough_places_available, \
+    update_booking, is_booking_limit_exceeded
 
 
 def test_has_enough_points_true():
@@ -26,3 +27,35 @@ def test_has_not_enough_places_available():
     }
     placesRequested = 10
     assert has_enough_places_available(competition, placesRequested) is False
+
+
+def test_update_booking_updates_points_and_places():
+    club = {'name': 'Club X', 'points': '20'}
+    competition = {'numberOfPlaces': '10', 'bookings': {'Club X': '2'}}
+    update_booking(club, competition, 3)
+    assert club['points'] == '17'
+    assert competition['numberOfPlaces'] == '7'
+    assert competition['bookings']['Club X'] == '5'
+
+
+def test_update_booking_creates_booking_key_if_absent():
+    club = {'name': 'Club X', 'points': '10'}
+    competition = {'numberOfPlaces': '5'}
+    update_booking(club, competition, 2)
+    assert competition['bookings']['Club X'] == '2'
+
+
+def test_is_booking_limit_exceeded_true():
+    comp = {'bookings': {'Club X': '10'}}
+    assert is_booking_limit_exceeded('Club X', comp, 3) is True
+
+
+def test_is_booking_limit_exceeded_false():
+    comp = {'bookings': {'Club X': '3'}}
+    assert is_booking_limit_exceeded('Club X', comp, 5) is False
+
+
+def test_is_booking_limit_exceeded_no_existing_booking():
+    comp = {'bookings': {}}
+    assert is_booking_limit_exceeded('Club X', comp, 10) is False
+


### PR DESCRIPTION
### What does this PR do?

this PR prevents clubs from booking more than 12 places per competition. 
It adds the is_booking_limit_exceeded function which compares the sum of already booked places and requested places with the maximum number of places allowed and return a boolean.
It also adds the update_booking function which it used to update the data of a club and competition after a reservation has been made : 
	- It reduces the number of places available for competition:
		We also remove requested places to the competition.
	- It records how many places this club has reserved for this competition:
		- If this is the first time we reserve for this competition, we create a "bookings" field in competition dictionnary to track reservations.
	- Then add the requested places to the total that this club has already booked.

This PR also adds functions saveClubs and saveCompetitions to prevent over-booking

### Closes Issue(s)

Closes #4
indirectly, it also solves issue 6
Closes #6

### How to test
- Execute :  flask --app server run
- Login with a valid email : john@simplylift.co
![image](https://github.com/user-attachments/assets/375997be-6e04-49d7-babc-3ab7fab23f4d)
- Choose Fall Classic link "Book Places"
- Try to book 13 places
![image](https://github.com/user-attachments/assets/6465207a-f1fa-44b8-8b56-8046e311e821)
- The error message is displayed
![image](https://github.com/user-attachments/assets/f8c147a4-8d04-4042-9a26-446a2c5bb09e)

### More
- The unit tests and the fonctionnal tests using Pytest are included