### PR TITLE
Fix prevent bookings for past competitions

### DIFF
--- a/competitions.json
+++ b/competitions.json
@@ -7,7 +7,7 @@
         },
         {
             "name": "Fall Classic",
-            "date": "2020-10-22 13:30:00",
+            "date": "2026-10-22 13:30:00",
             "numberOfPlaces": "13"
         }
     ]

--- a/server.py
+++ b/server.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import json
 from functools import wraps
 
@@ -44,10 +45,22 @@ def saveCompetitions(listOfCompetitions: list,
         json.dump({'competitions': listOfCompetitions}, c, indent=4)
 
 
+def get_list_ended_competitions(listOfCompetitions):
+    competitionsOver = []
+    for competition in listOfCompetitions:
+        comp_date = datetime.strptime(competition['date'],
+                                      "%Y-%m-%d %H:%M:%S")
+        if comp_date < datetime.now():
+            competitionsOver.append(competition)
+    return competitionsOver
+
+
 app = Flask(__name__)
 app.secret_key = 'something_special'
 
 competitions = loadCompetitions()
+competitionsEnded = get_list_ended_competitions(competitions)
+
 clubs = loadClubs()
 
 
@@ -66,6 +79,11 @@ def is_booking_limit_exceeded(club_name: str, competition: dict,
     """ check if the club is trying to book more than 12 places """
     bookedPlaces = int(competition.get("bookings", {}).get(club_name, 0))
     return bookedPlaces + requested > 12
+
+
+def is_competition_over(competition: dict, competitionsEnded: list) -> bool:
+    """ Check if a competition is in the list of the ended competition"""
+    return competition in competitionsEnded
 
 
 def update_booking(club: dict, competition: dict, requested: int) -> None:
@@ -107,23 +125,31 @@ def showSummary():
     club = session['club']
     return render_template('welcome.html',
                            club=club,
+                           competitionsEnded=competitionsEnded,
                            competitions=competitions)
 
 
-@app.route('/book/<competition>/<club>')
+@app.route('/book/<competition>')
 @login_required
-def book(competition,club):
-    foundClub = [c for c in clubs if c['name'] == club][0]
-    foundCompetition = [c for c in competitions if c['name'] == competition][0]
-    if foundClub and foundCompetition:
-        return render_template('booking.html',
-                               club=foundClub,
-                               competition=foundCompetition)
+def book(competition):
+
+    club = session.get('club')
+
+    competition = competition.strip()
+    foundCompetition = next((c for c in competitions
+                             if c['name'] == competition), None)
+
+    if foundCompetition:
+        if not is_competition_over(foundCompetition, competitionsEnded):
+            return render_template('booking.html',
+                                   club=club,
+                                   competition=foundCompetition)
+        else:
+            flash('this competition is already over')
     else:
         flash("Something went wrong-please try again")
-        return render_template('welcome.html',
-                               club=club,
-                               competitions=competitions)
+
+    return redirect(url_for('showSummary'))
 
 
 @app.route('/purchasePlaces',methods=['POST'])
@@ -150,9 +176,7 @@ def purchasePlaces():
 
         flash('Great-booking complete!')
 
-    return render_template('welcome.html',
-                           club=club,
-                           competitions=competitions)
+    return redirect(url_for('showSummary'))
 
 
 # TODO: Add route for points display

--- a/templates/booking.html
+++ b/templates/booking.html
@@ -8,7 +8,6 @@
     <h2>{{competition['name']}}</h2>
     Places available: {{competition['numberOfPlaces']}}
     <form action="/purchasePlaces" method="post">
-        <input type="hidden" name="club" value="{{club['name']}}">
         <input type="hidden" name="competition" value="{{competition['name']}}">
         <label for="places">How many places?</label><input type="number" name="places" id=""/>
         <button type="submit">Book</button>

--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -23,8 +23,8 @@
             {{comp['name']}}<br />
             Date: {{comp['date']}}</br>
             Number of Places: {{comp['numberOfPlaces']}}
-            {%if comp['numberOfPlaces']|int >0%}
-            <a href="{{ url_for('book',competition=comp['name'],club=club['name']) }}">Book Places</a>
+            {%if comp['numberOfPlaces']|int >0 and comp not in competitionsEnded %}
+            <a href="{{ url_for('book',competition=comp['name']) }}">Book Places</a>
             {%endif%}
         </li>
         <hr />

--- a/tests/test_functional_server.py
+++ b/tests/test_functional_server.py
@@ -77,8 +77,7 @@ def test_show_summary_renders_welcome(client, mocker, fake_data):
 def test_book_requires_login(client, fake_data):
     clubs, competitions = fake_data
     competition_name = competitions[1]['name']
-    club_name = clubs[0]['name']
-    response = client.get(f'/book/{competition_name}/{club_name}',
+    response = client.get(f'/book/{competition_name}',
                           follow_redirects=True)
     assert b"You must be logged in" in response.data
 
@@ -126,6 +125,7 @@ def test_successful_booking(client, mocker, fake_data):
     clubs, competitions = fake_data
     mocker.patch("server.clubs", clubs)
     mocker.patch("server.competitions", competitions)
+    mocker.patch("server.competitionsEnded", [competitions[0]])
     mocker.patch("server.saveClubs")
     mocker.patch("server.saveCompetitions")
 
@@ -151,6 +151,7 @@ def test_booking_without_enough_points(client, mocker, fake_data):
     competition = competitions[1]
     mocker.patch("server.clubs", clubs)
     mocker.patch("server.competitions", competitions)
+    mocker.patch("server.competitionsEnded", [competitions[0]])
     mocker.patch("server.saveClubs")
     mocker.patch("server.saveCompetitions")
 
@@ -172,6 +173,7 @@ def test_booking_more_than_available_places(client, mocker, fake_data):
 
     mocker.patch("server.clubs", clubs)
     mocker.patch("server.competitions", competitions)
+    mocker.patch("server.competitionsEnded", [competitions[0]])
     mocker.patch("server.saveClubs")
     mocker.patch("server.saveCompetitions")
 
@@ -194,7 +196,7 @@ def test_booking_too_much_places(client, mocker, fake_data):
 
     mocker.patch("server.clubs", clubs)
     mocker.patch("server.competitions", competitions)
-
+    mocker.patch("server.competitionsEnded", [competitions[0]])
     mocker.patch("server.saveClubs")
     mocker.patch("server.saveCompetitions")
 
@@ -207,4 +209,55 @@ def test_booking_too_much_places(client, mocker, fake_data):
     }, follow_redirects=True)
 
     assert b"you can&#39;t book more than 12 places." in response.data
+
+
+def test_book_past_competition(client, mocker, fake_data):
+    clubs, competitions = fake_data
+    club = clubs[0]
+    past_comp = competitions[0]
+
+    mocker.patch("server.clubs", clubs)
+    mocker.patch("server.competitions", competitions)
+    mocker.patch("server.competitionsEnded", [past_comp])
+
+    client.post('/login', data={'email': club['email']}, follow_redirects=True)
+
+    response = client.get(f'/book/{past_comp['name']}', data={
+        'competition': past_comp,
+
+    }, follow_redirects=True)
+
+    assert b"competition is already over" in response.data
+
+
+def test_book_valid_competition(client, mocker, fake_data):
+    clubs, competitions = fake_data
+    club = clubs[0]
+    competition = competitions[1]
+
+    mocker.patch("server.clubs", clubs)
+    mocker.patch("server.competitions", competitions)
+
+    client.post("/login", data={"email": club["email"]}, follow_redirects=True)
+
+    response = client.get(f"/book/{competition['name']}",
+                          follow_redirects=True)
+
+    assert response.status_code == 200
+    assert f"Booking for {competition['name']}" in str(response.data)
+
+
+def test_book_invalid_competition(client, mocker, fake_data):
+    clubs, competitions = fake_data
+    club = clubs[0]
+
+    mocker.patch("server.clubs", clubs)
+    mocker.patch("server.competitions", competitions)
+
+    client.post("/login", data={"email": club["email"]}, follow_redirects=True)
+
+    response = client.get("/book/Unknown Competition", follow_redirects=True)
+
+    assert response.status_code == 200
+    assert b"Something went wrong-please try again" in response.data
 

--- a/tests/test_unitaire_server.py
+++ b/tests/test_unitaire_server.py
@@ -1,6 +1,7 @@
 import pytest
 from server import has_enough_points, has_enough_places_available, \
-    update_booking, is_booking_limit_exceeded
+    update_booking, is_booking_limit_exceeded, get_list_ended_competitions, \
+    is_competition_over
 
 
 def test_has_enough_points_true():
@@ -59,3 +60,23 @@ def test_is_booking_limit_exceeded_no_existing_booking():
     comp = {'bookings': {}}
     assert is_booking_limit_exceeded('Club X', comp, 10) is False
 
+
+def test_get_list_Competitions_ended():
+    past = {'name': 'Past', 'date': '2020-01-01 10:00:00'}
+    future = {'name': 'Future',
+              'date': '2099-01-01 10:00:00'}
+    ended = get_list_ended_competitions([past, future])
+    assert past in ended
+    assert future not in ended
+
+
+def test_is_competition_over_true():
+    past_comp = {'name': 'Past Comp', 'date': '2022-01-01 10:00:00'}
+    competitionsEnded = get_list_ended_competitions([past_comp])
+    assert is_competition_over(past_comp, competitionsEnded) is True
+
+
+def test_is_competition_over_false():
+    future_comp = {'name': 'Future', 'date': '2099-01-01 10:00:00'}
+    competitionsEnded = get_list_ended_competitions([future_comp])
+    assert is_competition_over(future_comp, competitionsEnded) is False


### PR DESCRIPTION
### What does this PR do?

This PR prevents clubs from bookings for past competitions by no longer displaying the booking link on the template and by checking the book routes.
It adds function get_list_ended_competitions which create the list competitionsEnded. This list is passed into the template as context variables to hide the booking link. 
The book view use now the is_competition_over function to check if bookings are possible, and if it’s not, redirecte to the ShowSummary view, it prevents injection in the navigation bar.

**The club name is no-longer uses in dynamique route pattern for booking** 

### Closes Issue(s)
Closes #5

### How to test
- Execute :  flask --app server run
- Login with a valid email : john@simplylift.co
- The booking link is disabled for Spring Festival.
![Capture d'écran 2025-05-15 195804](https://github.com/user-attachments/assets/74b1ab50-deeb-4366-8710-28e0873d063d)
- Injects http://localhost:8000/book/Spring%20Festival/  into the browser’s address bar
- User is redirected to showsummary view
- The error message is displayed
![Capture d'écran 2025-05-15 184157](https://github.com/user-attachments/assets/8c44aba2-0328-4a57-a64d-fad2b5d6309f)

### More
- The unit tests and the fonctionnal tests using Pytest are included